### PR TITLE
Support for multiple AprilGrid calibration board

### DIFF
--- a/example_boards/aprilgrid_multiple.yaml
+++ b/example_boards/aprilgrid_multiple.yaml
@@ -1,0 +1,25 @@
+boards:
+  aprilgrid_0:
+    _type_: 'aprilgrid'
+    tag_length: 0.07
+    tag_spacing: 0.25
+    size: [8, 6]
+    start_id: 0
+    min_rows: 2
+    min_points: 12
+  aprilgrid_1:
+    _type_: 'aprilgrid'
+    tag_length: 0.07
+    tag_spacing: 0.25
+    size: [8, 6]
+    start_id: 48 # Start from different ID on different board
+    min_rows: 2
+    min_points: 12
+  aprilgrid_2:
+    _type_: 'aprilgrid'
+    tag_length: 0.07
+    tag_spacing: 0.25
+    size: [8, 6]
+    start_id: 96 # Start from different ID on different board
+    min_rows: 2
+    min_points: 12

--- a/multical/board/__init__.py
+++ b/multical/board/__init__.py
@@ -28,6 +28,7 @@ class AprilConfig:
   _type_: str = "aprilgrid"
   size : Tuple[int, int] = MISSING
 
+  start_id   : int = 0
   tag_family : str = "t36h11"
   tag_length : float = 0.06
   tag_spacing: float = 0.3

--- a/multical/board/aprilgrid.py
+++ b/multical/board/aprilgrid.py
@@ -20,12 +20,13 @@ def import_aprilgrid():
     error("aprilgrid support depends on apriltags2-ethz, a pip package (linux only)")      
 
 class AprilGrid(Parameters, Board):
-  def __init__(self, size, tag_length, 
-      tag_spacing, tag_family='t36h11', border_bits=2, min_rows=2, min_points=12, subpix_region=5, adjusted_points=None):
+  def __init__(self, size, tag_length, tag_spacing,
+      start_id=0, tag_family='t36h11', border_bits=2, min_rows=2, min_points=12, subpix_region=5, adjusted_points=None):
     
     assert tag_family in self.aruco_dicts
     self.size = tuple(size)
 
+    self.start_id = start_id
     self.tag_family = tag_family
     self.tag_spacing = tag_spacing
     self.tag_length = tag_length
@@ -42,10 +43,9 @@ class AprilGrid(Parameters, Board):
       aprilgrid = import_aprilgrid()
 
       w, h = self.size
-      family =  getattr(aprilgrid.tagFamilies, self.tag_family)
 
-      return aprilgrid.AprilGrid(h, w, self.tag_length, 
-        self.tag_spacing, family=family)
+      from multical.board.aprilgrid_detector import AprilGridDetector
+      return AprilGridDetector(h, w, self.tag_length, self.tag_spacing, start_id=self.start_id)
         
 
 
@@ -60,6 +60,7 @@ class AprilGrid(Parameters, Board):
   def export(self):
     return struct(
       type='aprilgrid',
+      start_id  = self.start_id,
       tag_family=self.tag_family,
       size = self.size,
       tag_length = self.tag_length,
@@ -194,6 +195,6 @@ class AprilGrid(Parameters, Board):
       return AprilGrid(**d)
 
   def __getstate__(self):
-    return subset(self.__dict__, ['size', 'tag_family', 'tag_length', 
+    return subset(self.__dict__, ['size', 'start_id', 'tag_family', 'tag_length', 
       'tag_spacing', 'min_rows', 'min_points', 'border_bits', 
       'subpix_region', 'adjusted_points'])

--- a/multical/board/aprilgrid_detector.py
+++ b/multical/board/aprilgrid_detector.py
@@ -1,0 +1,87 @@
+from apriltags_eth import make_default_detector
+from collections import namedtuple
+
+DetectionResult = namedtuple(
+    'DetectionResult', ['success', 'image_points', 'target_points', 'ids'])
+
+
+class AprilGridDetector(object):
+  """
+  https://github.com/safijari/apriltags2_ethz/blob/master/aprilgrid/__init__.py
+  Modification to support AprilGrid start_id so that we can use multiple
+  board
+
+  Just like the source, this only works with tagCodes36h11 because the python
+  binding of make_default_detector() doesn't accept any parameter
+  """
+  def __init__(self, rows, columns, size, spacing, start_id=0):
+    assert size != 0.0
+    assert spacing != 0.0
+    self.rows = rows
+    self.columns = columns
+    self.size = size
+    self.spacing = spacing
+    self.start_id = start_id
+    self.detector = make_default_detector()
+
+  def is_detection_valid(self, detection, image):
+    d = detection
+    h, w = image.shape[0:2]
+    for cx, cy in d.corners:
+      if cx < 0 or cx > w:
+        return False
+      if cy < 0 or cy > h:
+        return False
+    if not d.good:
+      return False
+    if d.id < self.start_id:
+      return False
+    if d.id >= self.rows * self.columns + self.start_id:
+      return False
+
+    return True
+
+  def get_tag_corners_for_id(self, tag_id):
+    # order is lower left, lower right, upper right, upper left
+    # Note: tag_id of lower left tag is 0, not 1
+    a = self.size
+    b = self.spacing * a
+    tag_row = (tag_id) // self.columns
+    tag_col = (tag_id) % self.columns
+    left = bottom = lambda i: i * (a + b)
+    right = top = lambda i: (i + 1) * a + (i) * b
+    return [(left(tag_col), bottom(tag_row)),
+            (right(tag_col), bottom(tag_row)),
+            (right(tag_col), top(tag_row)), (left(tag_col), top(tag_row))]
+
+  def compute_observation(self, image):
+    # return imagepoints and the coordinates of the corners
+    # 1. remove non good tags
+    detections = self.detector.extract_tags(image)
+
+    # Duplicate ID search
+    ids = {}
+    for d in detections:
+      if d.id in ids:
+        raise Exception("There may be two physical instances of the same tag in the image")
+      ids[d] = True
+
+    filtered = [d for d in detections if self.is_detection_valid(d, image)]
+
+    image_points = []
+    target_points = []
+    ids = []
+
+    filtered.sort(key=lambda x: x.id)
+
+    # TODO: subpix refinement?
+    for f in filtered:
+      # new id starting from 0 to not break anything else in the codebase
+      id = f.id - self.start_id
+      target_points.extend(self.get_tag_corners_for_id(id))
+      image_points.extend(f.corners)
+      ids.extend([id, id, id, id])
+
+    success = True if len(filtered) > 0 else False
+
+    return DetectionResult(success, image_points, target_points, ids)


### PR DESCRIPTION
Firstly, thank you very much for the great work and for sharing it!

This commit is trying to enable multiple april grid.

The concept is to have different board with different starting id. For example, the default board with 8x6 size are going to have id from 0-47. The next board will need to have different id, for example from 48-95, 96-143. 144-191, and so on.

I think the concept of start_id is pretty standard, for example [tagslam are using it](https://berndpfrommer.github.io/tagslam_web/input_files/) with this kind of configuration
```
  type: board
  board:
    tag_start_id: 12
    tag_size: 0.12
    tag_bits: 6
    tag_spacing: 0.25
    tag_rows: 2
    tag_columns: 3
```

And for this repository, I added example for 3 april grid calibration board that I used to the example_boards folder.
```
boards:
  aprilgrid_0:
    _type_: 'aprilgrid'
    tag_length: 0.07
    tag_spacing: 0.25
    size: [8, 6]
    start_id: 0
    min_rows: 2
    min_points: 12
  aprilgrid_1:
    _type_: 'aprilgrid'
    tag_length: 0.07
    tag_spacing: 0.25
    size: [8, 6]
    start_id: 48 # Start from different ID on different board
    min_rows: 2
    min_points: 12
  aprilgrid_2:
    _type_: 'aprilgrid'
    tag_length: 0.07
    tag_spacing: 0.25
    size: [8, 6]
    start_id: 96 # Start from different ID on different board
    min_rows: 2
    min_points: 12
```

To support this multiple aprilgrid board, I took the `aprilgrid.AprilGrid` class from apriltags2_ethz and put it in the multical/board/aprilgrid_detector.py. I modified so that it support start_id. Also, since it only work with t36h11 family(apriltags2_ethz also has this issue, because the underlying pybind11 doesn't accept the family parameter), I just remove the tag family parameter because it's not used.

The code changes might not suit what you like. So, please let me know if you have suggestions.

The result calibration result looks okay in my opinion, as we can see in the picture below

![Screenshot from 2021-04-22 02-09-55](https://user-images.githubusercontent.com/1798412/115593925-17db8a00-a310-11eb-9ead-289a0751af41.png)

![Screenshot from 2021-04-22 02-10-29](https://user-images.githubusercontent.com/1798412/115593970-2629a600-a310-11eb-880d-380983e83e1a.png)

