### PR TITLE
charuco detections are discarded if too few

### DIFF
--- a/multical/board/charuco.py
+++ b/multical/board/charuco.py
@@ -98,7 +98,7 @@ class CharucoBoard(Parameters, Board):
     _, corners, ids = cv2.aruco.interpolateCornersCharuco(
         corners, ids, image, self.board)
     
-    if ids is None: return empty_detection
+    if ids is None or len(ids) < 10: return empty_detection # DLT needs at least 6 points, 10 gives some margin
     return struct(corners = corners.squeeze(1), ids = ids.squeeze(1))
 
   def has_min_detections(self, detections):


### PR DESCRIPTION
This should avoid errors in opencv's camera calibration and the issues of https://github.com/oliver-batchelor/multical/issues/37